### PR TITLE
[EXPERIMENTAL] Very basic and untested Windows/MSVC support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,23 @@ project(letsplay
     DESCRIPTION "Emulator thing"
 )
 
+set(CMAKE_MODULE_PATH cmake)
+find_package(TurboJPEG REQUIRED)
+
 option(UseSTLFilesystem "Use std::filesystem instead of boost::filesystem" OFF)
 
+set(Boost_USE_STATIC_LIBS OFF)
+set(BUILD_SHARED_LIBS ON)
+set(Boost_NO_BOOST_CMAKE OFF)
+
 if(NOT UseSTLFilesystem)
-    find_package(Boost 1.62 COMPONENTS program_options filesystem REQUIRED)
+	find_package(Boost REQUIRED COMPONENTS system filesystem program_options)
 else()
-    find_package(Boost 1.62 COMPONENTS program_options REQUIRED)
+	find_package(Boost REQUIRED COMPONENTS system program_options)
 endif()
+
+find_package(Threads)
+find_package(JPEG REQUIRED)
 
 find_package(Git QUIET)
 if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
@@ -45,7 +55,7 @@ if(CMAKE_VERSION VERSION_GREATER 3.6)
         endif()
     endif()
 endif()
-]]
+## ]]
 
 if(NOT EXISTS "${PROJECT_SOURCE_DIR}/external/json/README.md")
     message(FATAL_ERROR "The json library submodule was not downloaded. Please manually update submodules and try again.")
@@ -75,6 +85,9 @@ set_target_properties(letsplay
         RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin
         )
 
+if(NOT WIN32)
+# TODO(modeco80): Figure out a way to make this work on the Windows because
+# microsoft big gay
 add_custom_target(update-client ALL
         DEPENDS
         ${CMAKE_SOURCE_DIR}/bin/client
@@ -82,16 +95,16 @@ add_custom_target(update-client ALL
         COMMAND git pull || (true && echo Local client change overriding remote change...) # Having this will prioritize local changes over remote ones
         COMMENT Updating client...
         )
-
 add_custom_command(
         OUTPUT
         ${CMAKE_SOURCE_DIR}/bin/client
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/bin
-        COMMAND git clone https://github.com/ctrlaltf2/lets-play-client client || true
+        COMMAND git clone https://github.com/ctrlaltf2/lets-play-client client
         COMMENT Fetching client..
         )
-
+		
 add_dependencies(letsplay update-client)
+endif()		
 
 target_compile_features(letsplay
     PUBLIC
@@ -116,10 +129,12 @@ target_include_directories(letsplay
     PUBLIC
         include
         include/common
-        ${Boost_INCLUDE_DIR}
+       # ${Boost_INCLUDE_DIR}
         external/json/single_include
+		${TURBOJPEG_INCLUDE_DIR}
 )
 
+if(UNIX)
 target_compile_options(letsplay
     PUBLIC
         -Wall
@@ -131,6 +146,7 @@ target_compile_options(letsplay
         -pedantic-errors
         -Wfatal-errors
 )
+endif()
 
 if(UseSTLFilesystem)
     target_link_libraries(letsplay
@@ -142,21 +158,30 @@ else()
         PRIVATE
             USE_BOOST_FILESYSTEM
     )
+	target_link_libraries(letsplay
+        PUBLIC
+            Boost::filesystem
+    )
 endif()
 
 if(UNIX)
     target_link_libraries(letsplay
         PUBLIC
             ${CMAKE_DL_LIBS}
+			${CMAKE_THREAD_LIBS_INIT}
     )
+endif()
+
+if(WIN32)
+target_link_libraries(letsplay
+    PUBLIC
+	bcrypt
+)
 endif()
 
 target_link_libraries(letsplay
     PUBLIC
-        pthread
-        boost_system
-        ${Boost_LIBRARIES}
-        turbojpeg
-        atomic
+        Boost::system
+		Boost::program_options
+        ${TURBOJPEG_LIBRARIES}
 )
-

--- a/cmake/FindTurboJPEG.cmake
+++ b/cmake/FindTurboJPEG.cmake
@@ -1,0 +1,138 @@
+# - Find TURBOJPEG
+# Find the libjpeg-turbo includes and library
+# This module defines
+#  TURBOJPEG_INCLUDE_DIR, where to find jpeglib.h and turbojpeg.h, etc.
+#  TURBOJPEG_LIBRARIES, the libraries needed to use libjpeg-turbo.
+#  TURBOJPEG_FOUND, If false, do not try to use libjpeg-turbo.
+# also defined, but not for general use are
+#  TURBOJPEG_LIBRARY, where to find the libjpeg-turbo library.
+
+#=============================================================================
+# Copyright 2001-2009 Kitware, Inc.
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+find_path(TURBOJPEG_PREFIX "include/turbojpeg.h"
+  $ENV{TURBOJPEG_HOME}
+  $ENV{EXTERNLIBS}/libjpeg-turbo64
+  $ENV{EXTERNLIBS}/libjpeg-turbo
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local/opt/jpeg-turbo # Homebrew
+  /usr/local
+  /usr
+  /sw # Fink
+  /opt/local # DarwinPorts
+  /opt/csw # Blastwave
+  /opt
+  DOC "TURBOJPEG - Prefix"
+)
+
+
+FIND_PATH(TURBOJPEG_INCLUDE_DIR "turbojpeg.h"
+  HINTS ${TURBOJPEG_PREFIX}/include
+  PATHS
+  $ENV{TURBOJPEG_HOME}/include
+  $ENV{EXTERNLIBS}/libjpeg-turbo64/include
+  $ENV{EXTERNLIBS}/libjpeg-turbo/include
+  ~/Library/Frameworks/include
+  /Library/Frameworks/include
+  /usr/local/opt/jpeg-turbo/include
+  /usr/local/include
+  /usr/include
+  /sw/include # Fink
+  /opt/local/include # DarwinPorts
+  /opt/csw/include # Blastwave
+  /opt/include
+  DOC "TURBOJPEG - Headers"
+)
+
+FIND_PATH(TURBOJPEG_INCLUDE_DIR_INT "jpegint.h"
+   PATHS ${TURBOJPEG_INCLUDE_DIR}
+   DOC "TURBOJPEG - Internal Headers"
+)
+
+FIND_LIBRARY(TURBOJPEG_LIBRARY turbojpeg
+  HINTS ${TURBOJPEG_PREFIX}/lib ${TURBOJPEG_PREFIX}/lib64
+  PATHS
+  $ENV{TURBOJPEG_HOME}
+  $ENV{EXTERNLIBS}/libjpeg-turbo64
+  $ENV{EXTERNLIBS}/libjpeg-turbo
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local
+  /usr/local/opt/jpeg-turbo
+  /usr
+  /sw
+  /opt/local
+  /opt/csw
+  /opt
+  PATH_SUFFIXES lib lib64
+  DOC "TURBOJPEG - Library"
+)
+
+
+if (MSVC)
+    FIND_LIBRARY(TURBOJPEG_LIBRARY_DEBUG turbojpegd
+        HINTS ${TURBOJPEG_PREFIX}/debug/lib ${TURBOJPEG_PREFIX}/debug/lib64 ${TURBOJPEG_PREFIX}/lib ${TURBOJPEG_PREFIX}/lib64
+        PATHS
+        $ENV{TURBOJPEG_HOME}
+        $ENV{EXTERNLIBS}/libjpeg-turbo64
+        $ENV{EXTERNLIBS}/libjpeg-turbo
+        ~/Library/Frameworks
+        /Library/Frameworks
+        /usr/local
+        /usr/local/opt/jpeg-turbo
+        /usr
+        /sw
+        /opt/local
+        /opt/csw
+        /opt
+        PATH_SUFFIXES debug/lib debug/lib64 lib lib64
+        DOC "TURBOJPEG - Library"
+    )
+endif()
+
+
+# handle the QUIETLY and REQUIRED arguments and set TURBOJPEG_FOUND to TRUE if 
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+if (MSVC)
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(TURBOJPEG DEFAULT_MSG
+        TURBOJPEG_INCLUDE_DIR
+        TURBOJPEG_LIBRARY TURBOJPEG_LIBRARY_DEBUG
+        TURBOJPEG_LIBRARY TURBOJPEG_LIBRARY_DEBUG)
+else()
+    FIND_PACKAGE_HANDLE_STANDARD_ARGS(TURBOJPEG DEFAULT_MSG TURBOJPEG_LIBRARY TURBOJPEG_LIBRARY TURBOJPEG_INCLUDE_DIR)
+endif()
+
+IF(TURBOJPEG_FOUND)
+    if (MSVC)
+        SET(TURBOJPEG_LIBRARIES optimized ${TURBOJPEG_LIBRARY} debug ${TURBOJPEG_LIBRARY_DEBUG})
+        SET(TURBOJPEG_LIBRARIES optimized ${TURBOJPEG_LIBRARY} debug ${TURBOJPEG_LIBRARY_DEBUG})
+    else()
+        SET(TURBOJPEG_LIBRARIES ${TURBOJPEG_LIBRARY})
+        SET(TURBOJPEG_LIBRARIES ${TURBOJPEG_LIBRARY})
+  endif()
+
+  INCLUDE (CheckSymbolExists)
+  set(CMAKE_REQUIRED_INCLUDES ${TURBOJPEG_INCLUDE_DIR})
+  CHECK_SYMBOL_EXISTS(tjMCUWidth "turbojpeg.h" TURBOJPEG_HAVE_TJMCUWIDTH)
+
+  if (TURBOJPEG_INCLUDE_DIR_INT)
+     set(TURBOJPEG_HAVE_INTERNAL TRUE)
+  else()
+     set(TURBOJPEG_HAVE_INTERNAL FALSE)
+  endif()
+
+ENDIF(TURBOJPEG_FOUND)
+
+MARK_AS_ADVANCED(TURBOJPEG_LIBRARY TURBOJPEG_LIBRARY TURBOJPEG_INCLUDE_DIR TURBOJPEG_HAVE_TJMCUWIDTH TURBOJPEG_HAVE_INTERNAL)

--- a/include/RetroCore.h
+++ b/include/RetroCore.h
@@ -66,4 +66,11 @@ class RetroCore {
      * Properly shuts down the retro core by calling deinit and similar.
      */
     ~RetroCore();
+
+private:
+
+	/**
+	 * Will be true if the core was loaded properly
+	 */
+	bool loaded_;
 };

--- a/src/Emulator/RetroCore.cpp
+++ b/src/Emulator/RetroCore.cpp
@@ -39,6 +39,8 @@ void RetroCore::Load(const char *corePath) {
         SaveStateSize = dll::import<size_t()>(corePath, "retro_serialize_size", dll::load_mode::rtld_now);
         SaveState = dll::import<bool(void *, size_t)>(corePath, "retro_serialize", dll::load_mode::rtld_now);
         LoadState = dll::import<bool(const void *, size_t)>(corePath, "retro_unserialize", dll::load_mode::rtld_now);
+
+		loaded_ = true;
     } catch (const boost::system::system_error &e) {
         std::cerr << "failed to load a libretro function: " << e.what() << '\n';
         std::exit(-3);
@@ -46,6 +48,9 @@ void RetroCore::Load(const char *corePath) {
 }
 
 RetroCore::~RetroCore() {
-    UnloadGame();
-    Deinit();
+
+	if (loaded_) {
+		UnloadGame();
+		Deinit();
+	}
 }

--- a/src/LetsPlayServer.cpp
+++ b/src/LetsPlayServer.cpp
@@ -1112,7 +1112,11 @@ void LetsPlayServer::SetupLetsPlayDirectories() {
         if (cXDGDataHome) { // Using XDG standard
             dataPath = lib::filesystem::path(cXDGDataHome) / "letsplay";
         } else { // If not, fall back to what XDG *would* use
+#if defined(__unix__) || defined(__APPLE__)
             dataPath = lib::filesystem::path(std::getenv("HOME")) / ".local" / "share" / "letsplay";
+#else
+			dataPath = lib::filesystem::path(std::getenv("LOCALAPPDATA")) / "letsplay";
+#endif
         }
     } else {
         dataPath = dataDir;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -19,7 +19,13 @@ int main(int argc, char **argv) {
     if (cXDGConfigHome)
         configPath = lib::filesystem::path(cXDGConfigHome) / "letsplay" / "config.json";
     else
+#if defined(__unix__) || defined(__APPLE__)
         configPath = lib::filesystem::path(std::getenv("HOME")) / ".config" / "letsplay" / "config.json";
+#else
+		// TODO(modeco80): probably finalize and discuss where things should actually go,
+		// but for now, this should hopefully cause things to not crash on windows
+		configPath = lib::filesystem::path(std::getenv("LOCALAPPDATA")) / "letsplay" / "config.json";
+#endif
 
     try {
         using namespace boost;


### PR DESCRIPTION
Title describes this well enough, however there is an additional fix that will benefit both Windows and *Nix:
- RetroCore destructor does not check if it *can* unload the dll, so it will always attempt to unload, potentially causing errors. I fixed this wrong behaviour.

If I have to fix tabs, please say so. I prefer hard tabs but I can fix if desired.